### PR TITLE
scrollable la liste des inputs, refacto

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,38 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Classes utilitaires pour masquer la scrollbar */
+.scrollbar-hide {
+  -ms-overflow-style: none; /* Internet Explorer 10+ */
+  scrollbar-width: none; /* Firefox */
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none; /* Safari et Chrome */
+}
+
+/* Alternative avec scrollbar personnalisée si besoin */
+.scrollbar-thin {
+  scrollbar-width: thin;
+}
+
+.scrollbar-thin::-webkit-scrollbar {
+  width: 4px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 2px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.2);
+}
+
 :root {
   --background: oklch(1 0 0);
   --foreground: oklch(0.3588 0.1354 278.6973);

--- a/src/components/ConfirmationSecret.tsx
+++ b/src/components/ConfirmationSecret.tsx
@@ -93,7 +93,7 @@ export function ConfirmationSecret({
           animate={error ? "shake" : { borderRadius: "1.2rem" }}
           variants={shakeAnimation}
           exit={{ scale: 0.95, opacity: 0 }}
-          className='relative z-50 w-full max-w-md overflow-hidden rounded-lg bg-background p-6 shadow-lg'>
+          className='relative z-50 max-w-md overflow-hidden rounded-lg bg-background p-6 shadow-lg'>
           <div className='flex items-center justify-between'>
             <h2 className='text-lg font-semibold'>{title}</h2>
             <Button

--- a/src/components/GenericBizPage.tsx
+++ b/src/components/GenericBizPage.tsx
@@ -72,7 +72,7 @@ export default function GenericBizPage({ config }: GenericBizPageProps) {
             </div>
           )}
 
-          <div className='flex flex-col items-center gap-4'>
+          <div className='flex flex-col items-center gap-4 max-h-[calc(100vh-120px)] overflow-y-auto scrollbar-hide'>
             <AnimatePresence>
               {entities.map((entity, index) => (
                 <motion.div


### PR DESCRIPTION
Actions:
- Rendre que la partie qui liste les inputs scrollable, et donc la page complète en non scrollable;
- Rendre invisible le scrollbar
- Diminution de la largeur de la modal de confirmation du secret